### PR TITLE
Refactor access control. Refactor RealDigital to meet docs.

### DIFF
--- a/contracts/CBDCAccessControl.sol
+++ b/contracts/CBDCAccessControl.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
-contract CBCDAccessControl is AccessControl {
+contract CBDCAccessControl is AccessControl {
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");

--- a/contracts/CBDCAccessControl.sol
+++ b/contracts/CBDCAccessControl.sol
@@ -9,11 +9,16 @@ contract CBDCAccessControl is AccessControl {
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant MOVER_ROLE = keccak256("MOVER_ROLE");
     bytes32 public constant ACCESS_ROLE = keccak256("ACCESS_ROLE");
+    bytes32 public constant FREEZER_ROLE = keccak256("FREEZER_ROLE");
 
     mapping(address => bool) public authorizedAccounts;
 
+    address public admin;
+    address public authority;
+
     event EnabledAccount(address indexed member);
     event DisabledAccount(address indexed member);
+    event AuthorityChanged(address indexed newAuthority);
 
     modifier checkAccess(address from, address to) {
         require(
@@ -25,12 +30,22 @@ contract CBDCAccessControl is AccessControl {
 
 
     constructor(address _authority, address _admin) {
+        admin = _admin;
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+
+        authority = _authority;
         _grantRole(BURNER_ROLE, _authority);
         _grantRole(MINTER_ROLE, _authority);
         _grantRole(PAUSER_ROLE, _authority);
         _grantRole(MOVER_ROLE, _authority);
         _grantRole(ACCESS_ROLE, _authority);
+        _grantRole(FREEZER_ROLE, _authority);
+    }
+
+    function changeAuthority(address newAuthority) public {
+        require(msg.sender == admin, "CBDCAccessControl: Only admin can change authority");
+        authority = newAuthority;
+        emit AuthorityChanged(newAuthority);
     }
 
     function disableAccount(address member) public onlyRole(ACCESS_ROLE) {

--- a/contracts/CBDCAccessControl.sol
+++ b/contracts/CBDCAccessControl.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract CBCDAccessControl is AccessControl {
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant MOVER_ROLE = keccak256("MOVER_ROLE");
+    bytes32 public constant ACCESS_ROLE = keccak256("ACCESS_ROLE");
+
+    mapping(address => bool) public authorizedAccounts;
+
+    event EnabledAccount(address indexed member);
+    event DisabledAccount(address indexed member);
+
+    modifier checkAccess(address from, address to) {
+        require(
+            authorizedAccounts[from] && authorizedAccounts[to],
+            "CBDCAccessControl: Both from and to accounts must be authorized"
+        );
+        _;
+    }
+
+
+    constructor(address _authority, address _admin) {
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+        _grantRole(BURNER_ROLE, _authority);
+        _grantRole(MINTER_ROLE, _authority);
+        _grantRole(PAUSER_ROLE, _authority);
+        _grantRole(MOVER_ROLE, _authority);
+        _grantRole(ACCESS_ROLE, _authority);
+    }
+
+    function disableAccount(address member) public onlyRole(ACCESS_ROLE) {
+        authorizedAccounts[member] = false;
+        emit DisabledAccount(member);
+    }
+
+    function enableAccount(address member) public onlyRole(ACCESS_ROLE) {
+        authorizedAccounts[member] = true;
+        emit EnabledAccount(member);
+    }
+
+    function verifyAccount(address account) public view virtual returns (bool) {
+        return authorizedAccounts[account];
+    }
+}

--- a/contracts/CBDCAccessControl.sol
+++ b/contracts/CBDCAccessControl.sol
@@ -22,9 +22,16 @@ contract CBDCAccessControl is AccessControl {
 
     modifier checkAccess(address from, address to) {
         require(
+            from != address(0) || to != address(0),
+            "CBDCAccessControl: Both from and to accounts cannot be zero"
+        );
+        require(
+            from == address(0) ||
+            to == address(0) ||
             authorizedAccounts[from] && authorizedAccounts[to],
             "CBDCAccessControl: Both from and to accounts must be authorized"
         );
+
         _;
     }
 

--- a/contracts/RealDigital.sol
+++ b/contracts/RealDigital.sol
@@ -44,7 +44,7 @@ contract RealDigital is ERC20, ERC20Burnable, Pausable, CBDCAccessControl {
     function transfer(
         address recipient,
         uint256 amount
-    ) public override whenNotPaused checkAccess(_msgSender(), recipient) returns (bool) {
+    ) public override whenNotPaused returns (bool) {
         return super.transfer(recipient, amount);
     }
 
@@ -52,7 +52,7 @@ contract RealDigital is ERC20, ERC20Burnable, Pausable, CBDCAccessControl {
         address sender,
         address recipient,
         uint256 amount
-    ) public override whenNotPaused checkAccess(sender, recipient) returns (bool) {
+    ) public override whenNotPaused returns (bool) {
         require(
             sender == _msgSender() || hasRole(MOVER_ROLE, _msgSender()),
             "RealDigital: msg.sender must be sender or have MOVER_ROLE"
@@ -93,7 +93,7 @@ contract RealDigital is ERC20, ERC20Burnable, Pausable, CBDCAccessControl {
         address from,
         address to,
         uint256 amount
-    ) internal override checkFrozenBalance(from, amount) {
+    ) internal override checkFrozenBalance(from, amount) checkAccess(from, to) {
         super._beforeTokenTransfer(from, to, amount);
     }
 }

--- a/contracts/RealDigital.sol
+++ b/contracts/RealDigital.sol
@@ -1,80 +1,50 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
+import "./CBDCAccessControl.sol";
 
-contract RealDigital is ERC20, ERC20Burnable, AccessControl, Pausable {
-    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
-    bytes32 public constant MOVER_ROLE = keccak256("MOVER_ROLE");
+contract RealDigital is ERC20, ERC20Burnable, Pausable, CBDCAccessControl {
+    mapping(address => uint256) public frozenBalanceOf;
 
-    mapping(address => bool) private _authorizedAccounts;
-    mapping(address => uint256) private _frozenBalances;
-
-    event DisabledAccount(address indexed member);
-    event EnabledAccount(address indexed member);
     event FrozenBalance(address indexed wallet, uint256 amount);
 
+    modifier checkFrozenBalance(address from, uint256 amount) {
+        require(
+            from == address(0) || balanceOf(from) - frozenBalanceOf[from] >= amount,
+            "RealDigital: Insufficient liquid balance"
+        );
+        _;
+    }
+
     constructor(
-        string memory name,
-        string memory symbol,
-        address authority
-    ) ERC20(name, symbol) {
-        _setupRole(DEFAULT_ADMIN_ROLE, authority);
-        _setupRole(BURNER_ROLE, authority);
-        _setupRole(MINTER_ROLE, authority);
-        _setupRole(PAUSER_ROLE, authority);
-        _setupRole(MOVER_ROLE, authority);
+        string memory _name,
+        string memory _symbol,
+        address _authority,
+        address _admin
+    ) ERC20(_name, _symbol) CBDCAccessControl(_authority, _admin) {}
+
+    function decimals() public view virtual override returns (uint8) {
+        return 2;
     }
 
-    function disableAccount(address member) public {
-        require(
-            hasRole(DEFAULT_ADMIN_ROLE, _msgSender()),
-            "Caller is not authorized"
-        );
-        _authorizedAccounts[member] = false;
-        emit DisabledAccount(member);
+    function increaseFrozenBalance(address from, uint256 amount) external whenNotPaused onlyRole(FREEZER_ROLE) {
+        frozenBalanceOf[from] += amount;
+        emit FrozenBalance(from, frozenBalanceOf[from]);
     }
 
-    function enableAccount(address member) public {
-        require(
-            hasRole(DEFAULT_ADMIN_ROLE, _msgSender()),
-            "Caller is not authorized"
-        );
-        _authorizedAccounts[member] = true;
-        emit EnabledAccount(member);
-    }
-
-    function increaseFrozenBalance(address from, uint256 amount) public {
-        require(hasRole(MOVER_ROLE, _msgSender()), "Caller is not authorized");
-        _frozenBalances[from] += amount;
-        emit FrozenBalance(from, _frozenBalances[from]);
-    }
-
-    function decreaseFrozenBalance(address from, uint256 amount) public {
-        require(hasRole(MOVER_ROLE, _msgSender()), "Caller is not authorized");
-        _frozenBalances[from] = _frozenBalances[from] > amount
-            ? _frozenBalances[from] - amount
-            : 0;
-        emit FrozenBalance(from, _frozenBalances[from]);
+    function decreaseFrozenBalance(address from, uint256 amount) external whenNotPaused onlyRole(FREEZER_ROLE) {
+        require(frozenBalanceOf[from] >= amount, "RealDigital: Insufficient frozen balance");
+        frozenBalanceOf[from] -= amount;
+        emit FrozenBalance(from, frozenBalanceOf[from]);
     }
 
     function transfer(
         address recipient,
         uint256 amount
-    ) public override whenNotPaused returns (bool) {
-        require(
-            _authorizedAccounts[_msgSender()] != false,
-            "Sender account is disabled"
-        );
-        require(
-            availableBalanceOf(_msgSender()) >= amount,
-            "Transfer amount exceeds available balance"
-        );
+    ) public override whenNotPaused checkAccess(_msgSender(), recipient) returns (bool) {
         return super.transfer(recipient, amount);
     }
 
@@ -82,74 +52,48 @@ contract RealDigital is ERC20, ERC20Burnable, AccessControl, Pausable {
         address sender,
         address recipient,
         uint256 amount
-    ) public override whenNotPaused returns (bool) {
+    ) public override whenNotPaused checkAccess(sender, recipient) returns (bool) {
         require(
-            _authorizedAccounts[sender] != false,
-            "Sender account is disabled"
-        );
-        require(
-            availableBalanceOf(sender) >= amount,
-            "Transfer amount exceeds available balance"
+            sender == _msgSender() || hasRole(MOVER_ROLE, _msgSender()),
+            "RealDigital: msg.sender must be sender or have MOVER_ROLE"
         );
         return super.transferFrom(sender, recipient, amount);
     }
 
-    function mint(address to, uint256 amount) public {
-        require(
-            hasRole(MINTER_ROLE, _msgSender()),
-            "Caller is not authorized to mint"
-        );
+    function mint(address to, uint256 amount) external whenNotPaused onlyRole(MINTER_ROLE) {
         _mint(to, amount);
     }
 
-    function burn(uint256 amount) public override {
-        require(
-            hasRole(BURNER_ROLE, _msgSender()),
-            "Caller is not authorized to burn"
-        );
+    function burn(uint256 amount) public override whenNotPaused onlyRole(BURNER_ROLE) {
         super.burn(amount);
     }
 
-    function pause() public {
-        require(
-            hasRole(PAUSER_ROLE, _msgSender()),
-            "Caller is not authorized to pause"
-        );
-        _pause();
+    function burnFrom(address account, uint256 amount) public override whenNotPaused onlyRole(BURNER_ROLE) {
+        super.burnFrom(account, amount);
     }
 
-    function unpause() public {
-        require(
-            hasRole(PAUSER_ROLE, _msgSender()),
-            "Caller is not authorized to unpause"
-        );
-        _unpause();
-    }
-
-    function availableBalanceOf(address account) public view returns (uint256) {
-        return balanceOf(account) - frozenBalanceOf(account);
-    }
-
-    function frozenBalanceOf(address account) public view returns (uint256) {
-        return _frozenBalances[account];
-    }
-
-    function authorizedAccount(address account) public view returns (bool) {
-        return _authorizedAccounts[account];
-    }
-
-    function move(address from, address to, uint256 amount) public {
+    function move(address from, address to, uint256 amount) public whenNotPaused onlyRole(MOVER_ROLE) {
         require(hasRole(MOVER_ROLE, _msgSender()), "Caller is not authorized");
         _transfer(from, to, amount);
     }
 
-    function moveAndBurn(address from, uint256 amount) public {
-        require(hasRole(MOVER_ROLE, _msgSender()), "Caller is not authorized");
+    function moveAndBurn(address from, uint256 amount) public whenNotPaused onlyRole(MOVER_ROLE){
         _burn(from, amount);
     }
 
-    function burnFrom(address account, uint256 amount) public override {
-        require(hasRole(BURNER_ROLE, _msgSender()), "Caller is not authorized");
-        _burn(account, amount);
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal override checkFrozenBalance(from, amount) {
+        super._beforeTokenTransfer(from, to, amount);
     }
 }

--- a/test/CBDCAccessControl.js
+++ b/test/CBDCAccessControl.js
@@ -1,0 +1,66 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const {
+  loadFixture,
+} = require("@nomicfoundation/hardhat-network-helpers");
+
+const deploy = async () => {
+    const CBCDAccessControl = await ethers.getContractFactory("CBCDAccessControl");
+    [admin, authority, testAccount] = await ethers.getSigners();
+    const accessControl = await CBCDAccessControl.deploy(authority.address, admin.address);
+    await accessControl.deployed();
+    return { accessControl, admin, authority, testAccount };
+}
+
+describe("CBCDAccessControl", function () {
+  let accessControl;
+  let admin;
+  let authority;
+  let testAccount;
+
+  beforeEach(async function () {
+    ({ accessControl, admin, authority, testAccount } = await loadFixture(deploy));
+  });
+
+  describe("Roles", function () {
+    it("should grant DEFAULT_ADMIN_ROLE role to admin", async function () {
+      expect(await accessControl.hasRole(await accessControl.DEFAULT_ADMIN_ROLE(), admin.address)).to.be.true;
+    });
+
+    it("should grant BURNER_ROLE to authority", async function () {
+      expect(await accessControl.hasRole(await accessControl.BURNER_ROLE(), authority.address)).to.be.true;
+    });
+
+    it("should grant MINTER_ROLE to authority", async function () {
+      expect(await accessControl.hasRole(await accessControl.MINTER_ROLE(), authority.address)).to.be.true;
+    });
+
+    it("should grant PAUSER_ROLE to authority", async function () {
+      expect(await accessControl.hasRole(await accessControl.PAUSER_ROLE(), authority.address)).to.be.true;
+    });
+
+    it("should grant MOVER_ROLE to authority", async function () {
+      expect(await accessControl.hasRole(await accessControl.MOVER_ROLE(), authority.address)).to.be.true;
+    });
+
+    it("should grant ACCESS_ROLE to authority", async function () {
+      expect(await accessControl.hasRole(await accessControl.ACCESS_ROLE(), authority.address)).to.be.true;
+    });
+  });
+
+  describe("Authorized Accounts", function () {
+    it("account with ACCESS_ROLE should enable and disable an account", async function () {
+      expect(await accessControl.verifyAccount(testAccount.address)).to.be.false;
+      await accessControl.connect(authority).enableAccount(testAccount.address);
+      expect(await accessControl.verifyAccount(testAccount.address)).to.be.true;
+      await accessControl.connect(authority).disableAccount(testAccount.address);
+      expect(await accessControl.verifyAccount(testAccount.address)).to.be.false;
+    });
+
+    it("account without ACCESS_ROLE should not enable and disable an account", async function () {
+        expect(
+            accessControl.enableAccount(testAccount)
+        ).to.be.revertedWith("AccessControl: account is missing the ACCESS_ROLE");
+    });
+  });
+});

--- a/test/CBDCAccessControl.js
+++ b/test/CBDCAccessControl.js
@@ -46,6 +46,10 @@ describe("CBDCAccessControl", function () {
     it("should grant ACCESS_ROLE to authority", async function () {
       expect(await accessControl.hasRole(await accessControl.ACCESS_ROLE(), authority.address)).to.be.true;
     });
+
+    it("should grant FREEZER_ROLE to authority", async function () {
+      expect(await accessControl.hasRole(await accessControl.FREEZER_ROLE(), authority.address)).to.be.true;
+    });
   });
 
   describe("Authorized Accounts", function () {
@@ -61,6 +65,19 @@ describe("CBDCAccessControl", function () {
         expect(
             accessControl.enableAccount(testAccount)
         ).to.be.revertedWith("AccessControl: account is missing the ACCESS_ROLE");
+    });
+  });
+
+  describe("Authority change", function () {
+    it("admin can change authority", async function () {
+      await accessControl.changeAuthority(testAccount.address);
+      expect(await accessControl.authority()).to.equal(testAccount.address);
+    });
+
+    it("non-admin can't change authority", async function () {
+        expect(
+            accessControl.connect(testAccount).changeAuthority(testAccount.address)
+        ).to.be.revertedWith("CBDCAccessControl: Only admin can change authority");
     });
   });
 });

--- a/test/CBDCAccessControl.js
+++ b/test/CBDCAccessControl.js
@@ -5,14 +5,14 @@ const {
 } = require("@nomicfoundation/hardhat-network-helpers");
 
 const deploy = async () => {
-    const CBCDAccessControl = await ethers.getContractFactory("CBCDAccessControl");
+    const CBCDAccessControl = await ethers.getContractFactory("CBDCAccessControl");
     [admin, authority, testAccount] = await ethers.getSigners();
     const accessControl = await CBCDAccessControl.deploy(authority.address, admin.address);
     await accessControl.deployed();
     return { accessControl, admin, authority, testAccount };
 }
 
-describe("CBCDAccessControl", function () {
+describe("CBDCAccessControl", function () {
   let accessControl;
   let admin;
   let authority;

--- a/test/RealDigital.js
+++ b/test/RealDigital.js
@@ -153,12 +153,17 @@ describe("RealDigital", function () {
   // Transfers
   describe("Transfers", function () {
     it("Should reject transfer to and from a disabled account", async function () {
-      const { real, authorizedSender, unauthorizedAccount } = await loadFixture(deployMintTokens);
+      const { real, authority, authorizedSender, unauthorizedAccount } = await loadFixture(deployMintTokens);
       await expect(
-        real.connect(authorizedSender).transfer(unauthorizedAccount.address, ethers.utils.parseEther("1"))
+        real.connect(authorizedSender).transfer(unauthorizedAccount.address, MINT_AMOUNT)
       ).to.be.revertedWith("CBDCAccessControl: Both from and to accounts must be authorized");
+
+      // the account needs to have funds, because the balance check happens before the account check
+      await real.connect(authority).enableAccount(unauthorizedAccount.address);
+      await real.connect(authority).mint(unauthorizedAccount.address, MINT_AMOUNT);
+      await real.connect(authority).disableAccount(unauthorizedAccount.address);
       await expect(
-        real.connect(unauthorizedAccount).transfer(authorizedSender.address, ethers.utils.parseEther("1"))
+        real.connect(unauthorizedAccount).transfer(authorizedSender.address, MINT_AMOUNT)
       ).to.be.revertedWith("CBDCAccessControl: Both from and to accounts must be authorized");
     });
 

--- a/util/constants.js
+++ b/util/constants.js
@@ -1,0 +1,9 @@
+const REAL_NAME = "Real Digital";
+const REAL_SYMBOL = "BRL";
+const REAL_DECIMALS = 2;
+
+module.exports = {
+    REAL_NAME,
+    REAL_SYMBOL,
+    REAL_DECIMALS
+}

--- a/util/parseFormatReal.js
+++ b/util/parseFormatReal.js
@@ -1,0 +1,15 @@
+const { ethers } = require("hardhat");
+const { REAL_DECIMALS } = require("./constants");
+
+const parseReal = (realString) => {
+    return ethers.utils.parseUnits(realString, REAL_DECIMALS);
+}
+
+const formatReal = (realBigNumber) => {
+    return ethers.utils.formatUnits(realBigNumber, REAL_DECIMALS);
+}
+
+module.exports = {
+    parseReal,
+    formatReal
+}

--- a/util/roles.js
+++ b/util/roles.js
@@ -1,0 +1,13 @@
+const { ethers } = require("hardhat");
+
+const roleKeccak = (role) => {
+    return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(role));
+}
+
+const getRoleError = (address, role) => {
+    return `AccessControl: account ${address.toLowerCase()} is missing role ${roleKeccak(role)}`;
+}
+
+module.exports = {
+    getRoleError
+}


### PR DESCRIPTION
This PR introduces the CBDCAccessControl contract that is in line with the [docs](https://github.com/krzysztof-cywinski/pilotord-kit-onboarding/blob/main/CBDCAccessControl.md)
It also changes the RealDigital contract to use the new CBDCAccessControl and in several places that didn't agree with the [docs](https://github.com/krzysztof-cywinski/pilotord-kit-onboarding/blob/main/RealDigital.md)

CBDCAccessControl is missing an ABI in the official docs
1. I assumed it used OZ AccessControl
2. I assumed stored admin and authority are public
3. I assumed that there is a function function changeAuthority(address newAuthority) public; that changes authority. CBDCAccessControl docs state in the constructor args definition that "Contract administrator, can change the authority of the contract if necessary"
4. I assumed that admin gets DEFAULT_ADMIN_ROLE
5. I assumed authority gets all roles **except** DEFAULT_ADMIN_ROLE
6. Added event AuthorityChanged(address indexed newAuthority);

RealDigital
1. Extended CBDCAccessControl instead of OZ AccessControl 
2. Changed _frozenBalances to frozenBalanceOf public to meet the ABI
3. Added whenNotPaused to all mutable functions
4. Changed requires to usage of onlyRole modifier
5. Moved frozen balance check as a modifier to _beforeTokenTransfer as defined in the RealDigital docs
6. Used the CBDCAccessControl::checkAccess modifier for transfers as that seems to be the intent in the CBDCAccessControl docs
7. I assumed that calling both burn and burnFrom requires the BURNER_ROLE. CBDCAccessControl doc states that BURNER_ROLE is "Role that allows access to the burn function." but RealDigital doc states that burnFrom "Destroys amount tokens from account, deducting the allowance from the executor. See {ERC20-_burn} and {ERC20-allowance}. Requirements: the executor must have authorization to move funds from accounts of at least amount." so it's not 100% clear if burnFrom requires BURNER_ROLE, but it would make sense.
8. in RealDigital docs for _beforeTokenTransfer I assumed that "from and to must be registered as participants." means they're authorized through enableAccount
9. in RealDigital::checkFrozenBalance skips check for mint scenario (from == address(0))

I also improved tests by adding fixtures, constants and utility functions