### PR TITLE
Feat: Address Discovery Contract Integration Test Suite

### DIFF
--- a/contracts/AddressDiscovery.sol
+++ b/contracts/AddressDiscovery.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./CBDCAccessControl.sol";
+
+contract AddressDiscovery is CBDCAccessControl {
+    mapping(bytes32 => address) public addressDiscovery;
+
+    constructor(address _authority, address _admin) CBDCAccessControl(_authority, _admin) {}
+
+    function updateAddress(bytes32 smartContract, address newAddress) public onlyRole(ACCESS_ROLE) {
+        addressDiscovery[smartContract] = newAddress;
+    }
+}

--- a/test/AddressDiscovery.js
+++ b/test/AddressDiscovery.js
@@ -1,0 +1,56 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const {
+    loadFixture,
+} = require("@nomicfoundation/hardhat-network-helpers");
+
+const deploy = async () => {
+    const AddressDiscovery = await ethers.getContractFactory("AddressDiscovery");
+    [admin, authority, testAccount] = await ethers.getSigners();
+    const addressDiscovery = await AddressDiscovery.deploy(authority.address, admin.address);
+    await addressDiscovery.deployed();
+    return { addressDiscovery, admin, authority, testAccount };
+}
+
+describe("AddressDiscovery", function () {
+    let addressDiscovery;
+    let admin;
+    let authority;
+    let testAccount;
+
+    beforeEach(async function () {
+        ({ addressDiscovery, admin, authority, testAccount } = await loadFixture(deploy));
+    });
+
+    describe("Update Address", function () {
+        it("should allow an account with ACCESS_ROLE to update address", async function () {
+            const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["string"], ["TEST_KEY"]));
+            await addressDiscovery.connect(authority).updateAddress(key, testAccount.address);
+            expect(await addressDiscovery.addressDiscovery(key)).to.equal(testAccount.address);
+        });
+
+        it("should not allow an account without ACCESS_ROLE to update address", async function () {
+            const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["string"], ["TEST_KEY"]));
+            const missingRole = await addressDiscovery.ACCESS_ROLE();
+            await expect(
+                addressDiscovery
+                    .connect(testAccount)
+                    .updateAddress(key, testAccount.address)
+            ).to.be.revertedWith(
+                `AccessControl: account ${testAccount.address.toLowerCase()} is missing role ${missingRole}`
+            );
+        });
+
+        it("admin can change authority", async function () {
+            await addressDiscovery.connect(admin).changeAuthority(testAccount.address);
+            expect(await addressDiscovery.authority()).to.equal(testAccount.address);
+        });
+
+        it("non-admin can't change authority", async function () {
+            expect(
+                addressDiscovery.connect(testAccount).changeAuthority(testAccount.address)
+            ).to.be.revertedWith("AddressDiscovery: Only admin can change authority");
+        });
+
+    });
+});


### PR DESCRIPTION
This PR introduces a new test suite for the `AddressDiscovery` smart contract. The tests ensure the contract's behavior aligns with its intended functionality.

Key changes:
- The `AddressDiscovery` test suite has been created, covering key interactions and permissions.
- Introduced `hardhat` and `chai` for contract deployment, interaction, and assertions.

```javascript
describe("AddressDiscovery", function () {
    it("should allow an account with ACCESS_ROLE to update address", async function () {...});
    it("should not allow an account without ACCESS_ROLE to update address", async function () {...});
    it("admin can change authority", async function () {...});
    it("non-admin can't change authority", async function () {...});
});
```

## Changes
1. **Test Setup**: Created a fixture for test setup using `loadFixture` function from `hardhat-network-helpers`. The fixture deploys the `AddressDiscovery` contract and also sets up some accounts for testing.

2. **Role Testing**: Wrote tests to ensure that the ACCESS_ROLE is respected when updating addresses in the contract.

3. **Authority Change Testing**: Wrote tests to ensure that only an admin can change the authority of the contract.

4. **Helper Methods**: Used `ethers.js` utilities for encoding and hashing data.

Please review these changes and let me know if any further adjustments are needed.

