### PR TITLE
Test refactor

### DIFF
--- a/contracts/AddressDiscovery.sol
+++ b/contracts/AddressDiscovery.sol
@@ -16,6 +16,8 @@ contract AddressDiscovery is AccessControl {
     constructor(address _authority, address _admin) {
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);
         _grantRole(ACCESS_ROLE, _authority);
+        authority = _authority;
+        admin = _admin;
     }
 
     function updateAddress(bytes32 smartContract, address newAddress) external onlyRole(ACCESS_ROLE) {

--- a/test/AddressDiscovery.js
+++ b/test/AddressDiscovery.js
@@ -29,9 +29,15 @@ describe("AddressDiscovery", function () {
   });
 
   it("admin can change authority", async function () {
-    const { addressDiscovery, unauthorizedAccount } = await loadFixture(deploy);
+    const { addressDiscovery, authority, unauthorizedAccount } = await loadFixture(deploy);
     await addressDiscovery.changeAuthority(unauthorizedAccount.address);
-    expect(await addressDiscovery.authority()).to.equal(unauthorizedAccount.address);
+    const accessRole = await addressDiscovery.ACCESS_ROLE();
+    expect(
+      await addressDiscovery.hasRole(accessRole, authority.address)
+    ).to.equal(false);
+    expect(
+      await addressDiscovery.hasRole(accessRole, unauthorizedAccount.address)
+    ).to.equal(true);
   });
 
   it("non-admin can't change authority", async function () {

--- a/test/RealDigital.js
+++ b/test/RealDigital.js
@@ -4,48 +4,15 @@ const { ethers } = require("hardhat");
 const {
   loadFixture,
 } = require("@nomicfoundation/hardhat-network-helpers");
-const { parseReal, formatReal } = require("../util/parseFormatReal");
 const { REAL_NAME, REAL_SYMBOL } = require("../util/constants");
 const { getRoleError } = require("../util/roles");
-
-const MINT_AMOUNT = parseReal("100");
-const FREEZE_AMOUNT = parseReal("50");
-
-const deploy = async () => {
-    const RealDigital = await ethers.getContractFactory("RealDigital");
-    [admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount] = await ethers.getSigners();
-    const real = await RealDigital.deploy(
-      REAL_NAME,
-      REAL_SYMBOL,
-      authority.address,
-      admin.address
-    );
-    await real.deployed();
-    return { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount };
-}
-
-const deployMintTokens = async () => {
-  const { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount } = await deploy();
-
-  await real.connect(authority).enableAccount(authority.address);
-  await real.connect(authority).enableAccount(authorizedSender.address);
-  await real.connect(authority).enableAccount(authorizedRecipient.address);
-
-  await real.connect(authority).mint(authority.address, MINT_AMOUNT);
-  expect(await real.balanceOf(authority.address)).to.equal(MINT_AMOUNT);
-
-  await real.connect(authority).mint(authorizedSender.address, MINT_AMOUNT);
-  expect(await real.balanceOf(authorizedSender.address)).to.equal(MINT_AMOUNT);
-
-  return { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount };
-}
-
-const deployMintAndFreezeTokens = async () => {
-  const { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount } = await deployMintTokens();
-  await real.connect(authority).increaseFrozenBalance(authorizedSender.address, FREEZE_AMOUNT);
-  return { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount };
-}
-
+const {
+  deploy,
+  deployMintTokens,
+  deployMintAndFreezeTokens,
+  MINT_AMOUNT,
+  FREEZE_AMOUNT,
+} = require("./fixtures/RealDigital");
 
 describe("RealDigital", function () {
 

--- a/test/RealDigitalDefaultAccount.js
+++ b/test/RealDigitalDefaultAccount.js
@@ -11,12 +11,12 @@ describe("RealDigitalDefaultAccount", function () {
   describe("addDefaultAccount", function () {
     it("Should add a new address", async function () {
       const { addressDiscovery, realDigitalDefaultAccount, authority, } = await loadFixture(deploy);
-      const { cnpj8 } = await deployRealTokenizado(addressDiscovery, realDigitalDefaultAccount);
+      const { realTokenizadoParams } = await deployRealTokenizado(addressDiscovery, realDigitalDefaultAccount);
       const randomWallet = ethers.Wallet.createRandom();
       await realDigitalDefaultAccount
         .connect(authority)
-        .addDefaultAccount(cnpj8, randomWallet.address);
-      expect(await realDigitalDefaultAccount.defaultAccount(cnpj8)).to.equal(
+        .addDefaultAccount(realTokenizadoParams.cnpj8, randomWallet.address);
+      expect(await realDigitalDefaultAccount.defaultAccount(realTokenizadoParams.cnpj8)).to.equal(
         randomWallet.address
       );
     });
@@ -31,18 +31,18 @@ describe("RealDigitalDefaultAccount", function () {
 
   describe("updateDefaultAccount", function () {
     it("Default account should be able to change to a different address", async function () {
-      const { realDigitalDefaultAccount, cnpj8, realTokenizado, defaultAccount } = await loadFixture(deployAddDefaultAccount);
+      const { realDigitalDefaultAccount, realTokenizadoParams, realTokenizado } = await loadFixture(deployAddDefaultAccount);
       const randomWallet = ethers.Wallet.createRandom();
-      await realDigitalDefaultAccount.connect(defaultAccount).updateDefaultAccount(cnpj8, randomWallet.address);
-      expect(await realDigitalDefaultAccount.defaultAccount(cnpj8)).to.equal(randomWallet.address);
+      await realDigitalDefaultAccount.connect(realTokenizadoParams.defaultAccount).updateDefaultAccount(realTokenizadoParams.cnpj8, randomWallet.address);
+      expect(await realDigitalDefaultAccount.defaultAccount(realTokenizadoParams.cnpj8)).to.equal(randomWallet.address);
       expect(await realTokenizado.hasRole(await realTokenizado.ACCESS_ROLE(), randomWallet.address)).to.equal(true);
       expect(await realTokenizado.hasRole(await realTokenizado.MOVER_ROLE(), randomWallet.address)).to.equal(true);
       expect(await realTokenizado.hasRole(await realTokenizado.FREEZER_ROLE(), randomWallet.address)).to.equal(true);
     });
 
     it("Unauthorized account should revert on updateDefaultAccount", async function () {
-      const { realDigitalDefaultAccount, cnpj8, unauthorized } = await loadFixture(deployAddDefaultAccount);
-      await expect(realDigitalDefaultAccount.connect(unauthorized).updateDefaultAccount(cnpj8, unauthorized.address)).to.be.revertedWith(
+      const { realDigitalDefaultAccount, realTokenizadoParams, unauthorized } = await loadFixture(deployAddDefaultAccount);
+      await expect(realDigitalDefaultAccount.connect(unauthorized).updateDefaultAccount(realTokenizadoParams.cnpj8, unauthorized.address)).to.be.revertedWith(
         "RealDigitalDefaultAccount: caller is not the default account"
       );
     });

--- a/test/RealTokenizado.js
+++ b/test/RealTokenizado.js
@@ -6,10 +6,10 @@ describe("RealTokenizado", () => {
 
   describe("constructor", () => {
     it("should set cnpj8, participant, and reserve", async () => {
-      const { realTokenizado, reserve, participant, cnpj8 } = await loadFixture(deployAddDefaultAccount);
-      expect(await realTokenizado.cnpj8()).to.equal(cnpj8);
-      expect(await realTokenizado.participant()).to.equal(participant);
-      expect(await realTokenizado.reserve()).to.equal(reserve.address);
+      const { realTokenizado, realTokenizadoParams } = await loadFixture(deployAddDefaultAccount);
+      expect(await realTokenizado.cnpj8()).to.equal(realTokenizadoParams.cnpj8);
+      expect(await realTokenizado.participant()).to.equal(realTokenizadoParams.participant);
+      expect(await realTokenizado.reserve()).to.equal(realTokenizadoParams.reserve.address);
     });
   });
 
@@ -22,8 +22,8 @@ describe("RealTokenizado", () => {
     });
 
     it("should update reserve", async () => {
-      const { realTokenizado, newReserve, defaultAccount } = await loadFixture(deployAddDefaultAccount);
-      await realTokenizado.connect(defaultAccount).updateReserve(newReserve.address);
+      const { realTokenizado, newReserve, realTokenizadoParams } = await loadFixture(deployAddDefaultAccount);
+      await realTokenizado.connect(realTokenizadoParams.defaultAccount).updateReserve(newReserve.address);
       expect(await realTokenizado.reserve()).to.equal(newReserve.address);
     });
   });

--- a/test/fixtures/RealDigital.js
+++ b/test/fixtures/RealDigital.js
@@ -1,0 +1,93 @@
+const { ethers } = require("hardhat");
+const { expect } = require("chai");
+const { parseReal } = require("../../util/parseFormatReal");
+const { REAL_NAME, REAL_SYMBOL } = require("../../util/constants");
+
+const MINT_AMOUNT = parseReal("100");
+const FREEZE_AMOUNT = parseReal("50");
+
+const deploy = async () => {
+  const RealDigital = await ethers.getContractFactory("RealDigital");
+  [
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  ] = await ethers.getSigners();
+  const real = await RealDigital.deploy(
+    REAL_NAME,
+    REAL_SYMBOL,
+    authority.address,
+    admin.address
+  );
+  await real.deployed();
+  return {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  };
+};
+
+const deployMintTokens = async () => {
+  const {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  } = await deploy();
+
+  await real.connect(authority).enableAccount(authority.address);
+  await real.connect(authority).enableAccount(authorizedSender.address);
+  await real.connect(authority).enableAccount(authorizedRecipient.address);
+
+  await real.connect(authority).mint(authority.address, MINT_AMOUNT);
+  expect(await real.balanceOf(authority.address)).to.equal(MINT_AMOUNT);
+
+  await real.connect(authority).mint(authorizedSender.address, MINT_AMOUNT);
+  expect(await real.balanceOf(authorizedSender.address)).to.equal(MINT_AMOUNT);
+
+  return {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  };
+};
+
+const deployMintAndFreezeTokens = async () => {
+  const {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  } = await deployMintTokens();
+  await real
+    .connect(authority)
+    .increaseFrozenBalance(authorizedSender.address, FREEZE_AMOUNT);
+  return {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  };
+};
+
+module.exports = {
+  deploy,
+  deployMintTokens,
+  deployMintAndFreezeTokens,
+  MINT_AMOUNT,
+  FREEZE_AMOUNT
+};

--- a/test/fixtures/RealTokenizado.js
+++ b/test/fixtures/RealTokenizado.js
@@ -23,7 +23,7 @@ class RealTokenizadoParams {
 
   getAddressDiscoveryKey() {
     return ethers.utils.keccak256(
-      ethers.utils.solidityPack(["string", "uint256"], [this.name, this.cnpj8])
+      ethers.utils.solidityPack(["string", "uint256"], ["RealTokenizado", this.cnpj8])
     );
   }
 }
@@ -87,7 +87,8 @@ const deploy = async (addressDiscovery, realDigitalDefaultAccount, realTokenizad
 
 const deployAddDefaultAccount = async (
   _addressDiscovery,
-  _realDigitalDefaultAccount
+  _realDigitalDefaultAccount,
+  _realTokenizadoParams
 ) => {
   const {
     addressDiscovery,
@@ -98,7 +99,7 @@ const deployAddDefaultAccount = async (
     realTokenizadoParams,
     newReserve,
     unauthorized,
-   } = await deploy(_addressDiscovery, _realDigitalDefaultAccount);
+   } = await deploy(_addressDiscovery, _realDigitalDefaultAccount, _realTokenizadoParams);
 
   await realDigitalDefaultAccount
     .connect(authority)


### PR DESCRIPTION
Refactors RealDigital tests for extract fixtures. Refactors RealTokenizado fixtures so that multiple RealTokenizado can be deployed with the same fixture using RealTokenizadoParams as a seed.

This branch is built on top of the RealDigitalDefaultAccount branch. Merge PR https://github.com/ioralabs/realdigital_smartcontracts/pull/12 before reviewing this one.