### PR TITLE
[DO NOT MERGE] Swap two steps

### DIFF
--- a/contracts/AddressDiscovery.sol
+++ b/contracts/AddressDiscovery.sol
@@ -16,6 +16,8 @@ contract AddressDiscovery is AccessControl {
     constructor(address _authority, address _admin) {
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);
         _grantRole(ACCESS_ROLE, _authority);
+        authority = _authority;
+        admin = _admin;
     }
 
     function updateAddress(bytes32 smartContract, address newAddress) external onlyRole(ACCESS_ROLE) {

--- a/test/AddressDiscovery.js
+++ b/test/AddressDiscovery.js
@@ -29,9 +29,15 @@ describe("AddressDiscovery", function () {
   });
 
   it("admin can change authority", async function () {
-    const { addressDiscovery, unauthorizedAccount } = await loadFixture(deploy);
+    const { addressDiscovery, authority, unauthorizedAccount } = await loadFixture(deploy);
     await addressDiscovery.changeAuthority(unauthorizedAccount.address);
-    expect(await addressDiscovery.authority()).to.equal(unauthorizedAccount.address);
+    const accessRole = await addressDiscovery.ACCESS_ROLE();
+    expect(
+      await addressDiscovery.hasRole(accessRole, authority.address)
+    ).to.equal(false);
+    expect(
+      await addressDiscovery.hasRole(accessRole, unauthorizedAccount.address)
+    ).to.equal(true);
   });
 
   it("non-admin can't change authority", async function () {

--- a/test/RealDigital.js
+++ b/test/RealDigital.js
@@ -4,48 +4,15 @@ const { ethers } = require("hardhat");
 const {
   loadFixture,
 } = require("@nomicfoundation/hardhat-network-helpers");
-const { parseReal, formatReal } = require("../util/parseFormatReal");
 const { REAL_NAME, REAL_SYMBOL } = require("../util/constants");
 const { getRoleError } = require("../util/roles");
-
-const MINT_AMOUNT = parseReal("100");
-const FREEZE_AMOUNT = parseReal("50");
-
-const deploy = async () => {
-    const RealDigital = await ethers.getContractFactory("RealDigital");
-    [admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount] = await ethers.getSigners();
-    const real = await RealDigital.deploy(
-      REAL_NAME,
-      REAL_SYMBOL,
-      authority.address,
-      admin.address
-    );
-    await real.deployed();
-    return { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount };
-}
-
-const deployMintTokens = async () => {
-  const { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount } = await deploy();
-
-  await real.connect(authority).enableAccount(authority.address);
-  await real.connect(authority).enableAccount(authorizedSender.address);
-  await real.connect(authority).enableAccount(authorizedRecipient.address);
-
-  await real.connect(authority).mint(authority.address, MINT_AMOUNT);
-  expect(await real.balanceOf(authority.address)).to.equal(MINT_AMOUNT);
-
-  await real.connect(authority).mint(authorizedSender.address, MINT_AMOUNT);
-  expect(await real.balanceOf(authorizedSender.address)).to.equal(MINT_AMOUNT);
-
-  return { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount };
-}
-
-const deployMintAndFreezeTokens = async () => {
-  const { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount } = await deployMintTokens();
-  await real.connect(authority).increaseFrozenBalance(authorizedSender.address, FREEZE_AMOUNT);
-  return { real, admin, authority, authorizedSender, authorizedRecipient, unauthorizedAccount };
-}
-
+const {
+  deploy,
+  deployMintTokens,
+  deployMintAndFreezeTokens,
+  MINT_AMOUNT,
+  FREEZE_AMOUNT,
+} = require("./fixtures/RealDigital");
 
 describe("RealDigital", function () {
 

--- a/test/RealDigital.js
+++ b/test/RealDigital.js
@@ -153,4 +153,30 @@ describe("RealDigital", function () {
     });
   });
 
+  describe("Move", function () {
+    it("Should reject move if caller doesn't have MOVER_ROLE", async function () {
+      const { real, authorizedSender, authorizedRecipient } = await loadFixture(deployMintAndFreezeTokens);
+      await expect(
+        real.connect(authorizedSender).move(authorizedSender.address, authorizedRecipient.address, MINT_AMOUNT)
+      ).to.be.revertedWith(getRoleError(authorizedSender.address, "MOVER_ROLE"));
+    });
+
+    it("Should allow move by authority", async function () {
+      const { real, authority, authorizedSender, authorizedRecipient } = await loadFixture(
+        deployMintTokens
+      );
+      const totalBalance = await real.balanceOf(authorizedSender.address);
+      const movedBalance = totalBalance.sub(1000);
+      await real
+        .connect(authority)
+        .move(authorizedSender.address, authorizedRecipient.address, movedBalance);
+      expect(await real.balanceOf(authorizedRecipient.address)).to.equal(
+        movedBalance
+      );
+      expect(await real.balanceOf(authorizedSender.address)).to.equal(
+        totalBalance.sub(movedBalance)
+      );
+    });
+  });
+
 });

--- a/test/RealDigitalDefaultAccount.js
+++ b/test/RealDigitalDefaultAccount.js
@@ -11,12 +11,12 @@ describe("RealDigitalDefaultAccount", function () {
   describe("addDefaultAccount", function () {
     it("Should add a new address", async function () {
       const { addressDiscovery, realDigitalDefaultAccount, authority, } = await loadFixture(deploy);
-      const { cnpj8 } = await deployRealTokenizado(addressDiscovery, realDigitalDefaultAccount);
+      const { realTokenizadoParams } = await deployRealTokenizado(addressDiscovery, realDigitalDefaultAccount);
       const randomWallet = ethers.Wallet.createRandom();
       await realDigitalDefaultAccount
         .connect(authority)
-        .addDefaultAccount(cnpj8, randomWallet.address);
-      expect(await realDigitalDefaultAccount.defaultAccount(cnpj8)).to.equal(
+        .addDefaultAccount(realTokenizadoParams.cnpj8, randomWallet.address);
+      expect(await realDigitalDefaultAccount.defaultAccount(realTokenizadoParams.cnpj8)).to.equal(
         randomWallet.address
       );
     });
@@ -31,18 +31,18 @@ describe("RealDigitalDefaultAccount", function () {
 
   describe("updateDefaultAccount", function () {
     it("Default account should be able to change to a different address", async function () {
-      const { realDigitalDefaultAccount, cnpj8, realTokenizado, defaultAccount } = await loadFixture(deployAddDefaultAccount);
+      const { realDigitalDefaultAccount, realTokenizadoParams, realTokenizado } = await loadFixture(deployAddDefaultAccount);
       const randomWallet = ethers.Wallet.createRandom();
-      await realDigitalDefaultAccount.connect(defaultAccount).updateDefaultAccount(cnpj8, randomWallet.address);
-      expect(await realDigitalDefaultAccount.defaultAccount(cnpj8)).to.equal(randomWallet.address);
+      await realDigitalDefaultAccount.connect(realTokenizadoParams.defaultAccount).updateDefaultAccount(realTokenizadoParams.cnpj8, randomWallet.address);
+      expect(await realDigitalDefaultAccount.defaultAccount(realTokenizadoParams.cnpj8)).to.equal(randomWallet.address);
       expect(await realTokenizado.hasRole(await realTokenizado.ACCESS_ROLE(), randomWallet.address)).to.equal(true);
       expect(await realTokenizado.hasRole(await realTokenizado.MOVER_ROLE(), randomWallet.address)).to.equal(true);
       expect(await realTokenizado.hasRole(await realTokenizado.FREEZER_ROLE(), randomWallet.address)).to.equal(true);
     });
 
     it("Unauthorized account should revert on updateDefaultAccount", async function () {
-      const { realDigitalDefaultAccount, cnpj8, unauthorized } = await loadFixture(deployAddDefaultAccount);
-      await expect(realDigitalDefaultAccount.connect(unauthorized).updateDefaultAccount(cnpj8, unauthorized.address)).to.be.revertedWith(
+      const { realDigitalDefaultAccount, realTokenizadoParams, unauthorized } = await loadFixture(deployAddDefaultAccount);
+      await expect(realDigitalDefaultAccount.connect(unauthorized).updateDefaultAccount(realTokenizadoParams.cnpj8, unauthorized.address)).to.be.revertedWith(
         "RealDigitalDefaultAccount: caller is not the default account"
       );
     });

--- a/test/RealTokenizado.js
+++ b/test/RealTokenizado.js
@@ -6,10 +6,10 @@ describe("RealTokenizado", () => {
 
   describe("constructor", () => {
     it("should set cnpj8, participant, and reserve", async () => {
-      const { realTokenizado, reserve, participant, cnpj8 } = await loadFixture(deployAddDefaultAccount);
-      expect(await realTokenizado.cnpj8()).to.equal(cnpj8);
-      expect(await realTokenizado.participant()).to.equal(participant);
-      expect(await realTokenizado.reserve()).to.equal(reserve.address);
+      const { realTokenizado, realTokenizadoParams } = await loadFixture(deployAddDefaultAccount);
+      expect(await realTokenizado.cnpj8()).to.equal(realTokenizadoParams.cnpj8);
+      expect(await realTokenizado.participant()).to.equal(realTokenizadoParams.participant);
+      expect(await realTokenizado.reserve()).to.equal(realTokenizadoParams.reserve.address);
     });
   });
 
@@ -22,8 +22,8 @@ describe("RealTokenizado", () => {
     });
 
     it("should update reserve", async () => {
-      const { realTokenizado, newReserve, defaultAccount } = await loadFixture(deployAddDefaultAccount);
-      await realTokenizado.connect(defaultAccount).updateReserve(newReserve.address);
+      const { realTokenizado, newReserve, realTokenizadoParams } = await loadFixture(deployAddDefaultAccount);
+      await realTokenizado.connect(realTokenizadoParams.defaultAccount).updateReserve(newReserve.address);
       expect(await realTokenizado.reserve()).to.equal(newReserve.address);
     });
   });

--- a/test/SwapOneStep.js
+++ b/test/SwapOneStep.js
@@ -1,0 +1,125 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const {
+  deployWithRealTokenizado,
+  INITIAL_BALANCE,
+} = require("./fixtures/SwapOneStep");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("SwapOneStep", function () {
+  describe("executeSwap", function () {
+    it("Should swap tokens", async function () {
+      const {
+        swapOneStep,
+        realDigital,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+      const expectedSenderBalancePost = INITIAL_BALANCE.sub(amount);
+
+      await realTokenizado1.connect(enabledSender).increaseAllowance(swapOneStep.address, amount);
+
+      expect(realTokenizado1.address).to.not.be.equal(realTokenizado2.address);
+      expect(await realTokenizado1.reserve()).to.not.be.equal(await realTokenizado2.reserve());
+      expect(await realDigital.balanceOf(realTokenizado1.reserve())).to.equal(INITIAL_BALANCE);
+      expect(await realDigital.balanceOf(realTokenizado2.reserve())).to.equal(0);
+
+      await swapOneStep
+        .connect(enabledSender)
+        .executeSwap(
+          realTokenizado1.address,
+          realTokenizado2.address,
+          enabledRecipient.address,
+          amount
+        );
+
+      const senderBalancePost = await realTokenizado1.balanceOf(
+        enabledSender.address
+      );
+      const recipientBalancePost = await realTokenizado2.balanceOf(
+        enabledRecipient.address
+      );
+
+      expect(senderBalancePost).to.equal(expectedSenderBalancePost);
+      expect(recipientBalancePost).to.equal(amount);
+
+      const senderParticipantRealBalancePost = await realDigital.balanceOf(
+        realTokenizado1.reserve()
+      );
+      const recipientParticipantRealBalancePost = await realDigital.balanceOf(
+        realTokenizado2.reserve()
+      );
+
+      expect(senderParticipantRealBalancePost).to.equal(expectedSenderBalancePost);
+      expect(recipientParticipantRealBalancePost).to.equal(amount);
+    });
+
+    it("Should revert if sender is not enabled", async function () {
+      const {
+        swapOneStep,
+        realTokenizado1,
+        realTokenizado2,
+        unauthorized,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await expect(
+        swapOneStep
+          .connect(unauthorizedAccount)
+          .executeSwap(
+            realTokenizado1.address,
+            realTokenizado2.address,
+            unauthorized.address,
+            amount
+          )
+      ).to.be.revertedWith("SwapOneStep: Sender is not authorized");
+    });
+
+    it("Should revert if recipient is not enabled", async function () {
+      const {
+        swapOneStep,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        unauthorized,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await expect(
+        swapOneStep
+          .connect(enabledSender)
+          .executeSwap(
+            realTokenizado1.address,
+            realTokenizado2.address,
+            unauthorized.address,
+            amount
+          )
+      ).to.be.revertedWith("SwapOneStep: Receiver is not authorized");
+    });
+
+    it("Should revert on insufficient balance", async function () {
+      const {
+        swapOneStep,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.add(20000);
+
+      await expect(
+        swapOneStep
+          .connect(enabledSender)
+          .executeSwap(
+            realTokenizado1.address,
+            realTokenizado2.address,
+            enabledRecipient.address,
+            amount
+          )
+      ).to.be.revertedWith("SwapOneStep: Sender does not have enough balance");
+    });
+  });
+});

--- a/test/SwapOneStep.js
+++ b/test/SwapOneStep.js
@@ -1,33 +1,33 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const {
-  deployWithRealTokenizado,
+  deployOneStepWithRealTokenizado: deployWithRealTokenizado,
   INITIAL_BALANCE,
-} = require("./fixtures/SwapOneStep");
+} = require("./fixtures/Swaps");
 const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("SwapOneStep", function () {
   describe("executeSwap", function () {
     it("Should swap tokens", async function () {
       const {
-        swapOneStep,
+        swap,
         realDigital,
         realTokenizado1,
         realTokenizado2,
         enabledSender,
         enabledRecipient,
-      } = await loadFixture(deployWithRealTokenizado);
+      } = await deployWithRealTokenizado();
       const amount = INITIAL_BALANCE.sub(20000);
       const expectedSenderBalancePost = INITIAL_BALANCE.sub(amount);
 
-      await realTokenizado1.connect(enabledSender).increaseAllowance(swapOneStep.address, amount);
+      await realTokenizado1.connect(enabledSender).increaseAllowance(swap.address, amount);
 
       expect(realTokenizado1.address).to.not.be.equal(realTokenizado2.address);
       expect(await realTokenizado1.reserve()).to.not.be.equal(await realTokenizado2.reserve());
       expect(await realDigital.balanceOf(realTokenizado1.reserve())).to.equal(INITIAL_BALANCE);
       expect(await realDigital.balanceOf(realTokenizado2.reserve())).to.equal(0);
 
-      await swapOneStep
+      await swap
         .connect(enabledSender)
         .executeSwap(
           realTokenizado1.address,
@@ -59,7 +59,7 @@ describe("SwapOneStep", function () {
 
     it("Should revert if sender is not enabled", async function () {
       const {
-        swapOneStep,
+        swap,
         realTokenizado1,
         realTokenizado2,
         unauthorized,
@@ -67,7 +67,7 @@ describe("SwapOneStep", function () {
       const amount = INITIAL_BALANCE.sub(20000);
 
       await expect(
-        swapOneStep
+        swap
           .connect(unauthorizedAccount)
           .executeSwap(
             realTokenizado1.address,
@@ -80,7 +80,7 @@ describe("SwapOneStep", function () {
 
     it("Should revert if recipient is not enabled", async function () {
       const {
-        swapOneStep,
+        swap,
         realTokenizado1,
         realTokenizado2,
         enabledSender,
@@ -89,7 +89,7 @@ describe("SwapOneStep", function () {
       const amount = INITIAL_BALANCE.sub(20000);
 
       await expect(
-        swapOneStep
+        swap
           .connect(enabledSender)
           .executeSwap(
             realTokenizado1.address,
@@ -102,7 +102,7 @@ describe("SwapOneStep", function () {
 
     it("Should revert on insufficient balance", async function () {
       const {
-        swapOneStep,
+        swap,
         realTokenizado1,
         realTokenizado2,
         enabledSender,
@@ -111,7 +111,7 @@ describe("SwapOneStep", function () {
       const amount = INITIAL_BALANCE.add(20000);
 
       await expect(
-        swapOneStep
+        swap
           .connect(enabledSender)
           .executeSwap(
             realTokenizado1.address,

--- a/test/SwapTwoSteps.js
+++ b/test/SwapTwoSteps.js
@@ -1,0 +1,341 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const {
+  deployTwoStepsWithRealTokenizado: deployWithRealTokenizado,
+  INITIAL_BALANCE,
+} = require("./fixtures/Swaps");
+const { deployInitiateSwap } = require("./fixtures/SwapTwoStep");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { setNextBlockTimestamp } = require("@nomicfoundation/hardhat-network-helpers/dist/src/helpers/time");
+
+const EXPIRATION_TIME = 60;
+
+describe("SwapTwoSteps", function () {
+  describe("startSwap", function () {
+    it("Should start a swap", async function () {
+      const {
+        swap,
+        realDigital,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await realTokenizado1.connect(enabledSender).increaseAllowance(swap.address, amount);
+
+      const senderFrozenBefore = await realTokenizado1.frozenBalanceOf(
+        enabledSender.address
+      );
+      const cbdcFrozenBefore = await realDigital.frozenBalanceOf(
+        realTokenizado1.reserve()
+      );
+
+      await swap
+        .connect(enabledSender)
+        .startSwap(
+          realTokenizado1.address,
+          realTokenizado2.address,
+          enabledRecipient.address,
+          amount
+        );
+
+      expect(await realTokenizado1.frozenBalanceOf(enabledSender.address)).to.equal(senderFrozenBefore.add(amount));
+      expect(await realDigital.frozenBalanceOf(realTokenizado1.reserve())).to.equal(cbdcFrozenBefore.add(amount));
+
+      const proposal = await swap.swapProposals(0);
+      expect(proposal.sender).to.equal(enabledSender.address);
+      expect(proposal.receiver).to.equal(enabledRecipient.address);
+      expect(proposal.amount).to.equal(amount);
+      expect(proposal.tokenSender).to.equal(realTokenizado1.address);
+      expect(proposal.tokenReceiver).to.equal(realTokenizado2.address);
+    });
+
+    it("Should revert if sender is not enabled", async function () {
+      const {
+        swap,
+        realTokenizado1,
+        realTokenizado2,
+        unauthorized,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await expect(
+        swap
+          .connect(unauthorizedAccount)
+          .startSwap(
+            realTokenizado1.address,
+            realTokenizado2.address,
+            unauthorized.address,
+            amount
+          )
+      ).to.be.revertedWith("SwapTwoSteps: Sender is not authorized");
+    });
+
+    it("Should revert if recipient is not enabled", async function () {
+      const {
+        swap,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        unauthorized,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await expect(
+        swap
+          .connect(enabledSender)
+          .startSwap(
+            realTokenizado1.address,
+            realTokenizado2.address,
+            unauthorized.address,
+            amount
+          )
+      ).to.be.revertedWith("SwapTwoSteps: Receiver is not authorized");
+    });
+
+    it("Should revert on insufficient balance", async function () {
+      const {
+        swap,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.add(20000);
+
+      await expect(
+        swap
+          .connect(enabledSender)
+          .startSwap(
+            realTokenizado1.address,
+            realTokenizado2.address,
+            enabledRecipient.address,
+            amount
+          )
+      ).to.be.revertedWith("SwapTwoSteps: Sender does not have enough balance");
+    });
+  });
+
+  describe("executeSwap", function () {
+    it("Should execute a swap", async function () {
+      const {
+        swap,
+        realDigital,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      let proposal = await swap.swapProposals(proposalId);
+      const senderBalanceBefore = await realTokenizado1.balanceOf(enabledSender.address);
+      const recipientBalanceBefore = await realTokenizado2.balanceOf(enabledRecipient.address);
+      const cbdcParticipant1BalanceBefore = await realDigital.balanceOf(realTokenizado1.reserve());
+      const cbdcParticipant2BalanceBefore = await realDigital.balanceOf(realTokenizado2.reserve());
+
+      await swap.connect(enabledRecipient).executeSwap(proposalId);
+
+      expect(await realTokenizado1.balanceOf(enabledSender.address)).to.equal(senderBalanceBefore.sub(proposal.amount));
+      expect(await realTokenizado2.balanceOf(enabledRecipient.address)).to.equal(recipientBalanceBefore.add(proposal.amount));
+      expect(await realDigital.balanceOf(realTokenizado1.reserve())).to.equal(cbdcParticipant1BalanceBefore.sub(proposal.amount));
+      expect(await realDigital.balanceOf(realTokenizado2.reserve())).to.equal(cbdcParticipant2BalanceBefore.add(proposal.amount));
+
+      proposal = await swap.swapProposals(proposalId);
+      expect(proposal.status).to.equal(1);
+    });
+
+    it("Should revert if proposal does not exist", async function () {
+      const {
+        swap,
+        enabledRecipient,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await expect(
+        swap
+          .connect(enabledRecipient)
+          .executeSwap(0)
+      ).to.be.revertedWith("SwapTwoSteps: Proposal does not exist");
+    });
+
+    it("Should revert if caller is not the receiver", async function () {
+      const {
+        swap,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      await expect(
+        swap.connect(enabledSender).executeSwap(proposalId)
+      ).to.be.revertedWith(
+        "SwapTwoSteps: Only the receiver can accept the swap"
+      );
+    });
+
+    it("Should revert if proposal is not in status 0", async function () {
+      const {
+        swap,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      await swap.connect(enabledRecipient).cancelSwap(proposalId, "test");
+
+      await expect(
+        swap.connect(enabledRecipient).executeSwap(proposalId)
+      ).to.be.revertedWith(
+        "SwapTwoSteps: Proposal already closed"
+      );
+    });
+
+    it("Should revert if proposal expired", async function () {
+      const {
+        swap,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      const proposal = await swap.swapProposals(proposalId);
+      await setNextBlockTimestamp(proposal.timestamp.toNumber() + EXPIRATION_TIME + 1);
+
+      await expect(
+        swap.connect(enabledRecipient).executeSwap(proposalId)
+      ).to.be.revertedWith(
+        "SwapTwoSteps: Proposal expired"
+      );
+    });
+  });
+
+  describe("cancelSwap", function () {
+    it("Sender can cancel a swap", async function () {
+      const {
+        swap,
+        realDigital,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      const senderBalanceBefore = await realTokenizado1.balanceOf(enabledSender.address);
+      const cbdcParticipant1BalanceBefore = await realDigital.balanceOf(realTokenizado1.reserve());
+      const receiverBalanceBefore = await realTokenizado2.balanceOf(enabledRecipient.address);
+      const cbdcParticipant2BalanceBefore = await realDigital.balanceOf(realTokenizado2.reserve());
+
+      await swap.connect(enabledSender).cancelSwap(proposalId, "test");
+
+      expect(await realTokenizado1.balanceOf(enabledSender.address)).to.equal(senderBalanceBefore);
+      expect(await realDigital.balanceOf(realTokenizado1.reserve())).to.equal(cbdcParticipant1BalanceBefore);
+      expect(await realTokenizado2.balanceOf(enabledRecipient.address)).to.equal(receiverBalanceBefore);
+      expect(await realDigital.balanceOf(realTokenizado2.reserve())).to.equal(cbdcParticipant2BalanceBefore);
+
+      const proposalAfter = await swap.swapProposals(proposalId);
+      expect(proposalAfter.status).to.equal(2);
+    });
+
+    it("Receiver can cancel a swap", async function () {
+      const {
+        swap,
+        realDigital,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      const senderBalanceBefore = await realTokenizado1.balanceOf(enabledSender.address);
+      const cbdcParticipant1BalanceBefore = await realDigital.balanceOf(realTokenizado1.reserve());
+      const receiverBalanceBefore = await realTokenizado2.balanceOf(enabledRecipient.address);
+      const cbdcParticipant2BalanceBefore = await realDigital.balanceOf(realTokenizado2.reserve());
+
+      await swap.connect(enabledRecipient).cancelSwap(proposalId, "test");
+
+      expect(await realTokenizado1.balanceOf(enabledSender.address)).to.equal(senderBalanceBefore);
+      expect(await realDigital.balanceOf(realTokenizado1.reserve())).to.equal(cbdcParticipant1BalanceBefore);
+      expect(await realTokenizado2.balanceOf(enabledRecipient.address)).to.equal(receiverBalanceBefore);
+      expect(await realDigital.balanceOf(realTokenizado2.reserve())).to.equal(cbdcParticipant2BalanceBefore);
+
+      const proposalAfter = await swap.swapProposals(proposalId);
+      expect(proposalAfter.status).to.equal(2);
+    });
+
+    it("Unauthorized can't cancel a swap", async function () {
+      const {
+        swap,
+        unauthorized,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      await expect(
+        swap.connect(unauthorized).cancelSwap(proposalId, "test")
+      ).to.be.revertedWith("SwapTwoSteps: Only the sender or receiver can cancel the swap");
+    });
+
+    it("Anyone can cancel a swap if expired", async function () {
+      const {
+        swap,
+        realDigital,
+        realTokenizado1,
+        realTokenizado2,
+        enabledSender,
+        enabledRecipient,
+        unauthorized,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      const proposal = await swap.swapProposals(proposalId);
+      await setNextBlockTimestamp(proposal.timestamp.toNumber() + EXPIRATION_TIME + 1);
+
+      const senderBalanceBefore = await realTokenizado1.balanceOf(enabledSender.address);
+      const cbdcParticipant1BalanceBefore = await realDigital.balanceOf(realTokenizado1.reserve());
+      const receiverBalanceBefore = await realTokenizado2.balanceOf(enabledRecipient.address);
+      const cbdcParticipant2BalanceBefore = await realDigital.balanceOf(realTokenizado2.reserve());
+
+      await swap.connect(unauthorized).cancelSwap(proposalId, "test");
+
+      expect(await realTokenizado1.balanceOf(enabledSender.address)).to.equal(senderBalanceBefore);
+      expect(await realDigital.balanceOf(realTokenizado1.reserve())).to.equal(cbdcParticipant1BalanceBefore);
+      expect(await realTokenizado2.balanceOf(enabledRecipient.address)).to.equal(receiverBalanceBefore);
+      expect(await realDigital.balanceOf(realTokenizado2.reserve())).to.equal(cbdcParticipant2BalanceBefore);
+
+      const proposalAfter = await swap.swapProposals(proposalId);
+      expect(proposalAfter.status).to.equal(2);
+    });
+
+    it("Can't cancel an executed swap", async function () {
+      const {
+        swap,
+        enabledRecipient,
+        proposalId
+      } = await loadFixture(deployInitiateSwap);
+
+      await swap.connect(enabledRecipient).executeSwap(proposalId);
+
+      await expect(
+        swap.connect(enabledRecipient).cancelSwap(proposalId, "test")
+      ).to.be.revertedWith("SwapTwoSteps: Proposal already closed");
+    });
+
+    it("Should revert if proposal does not exist", async function () {
+      const {
+        swap,
+        enabledRecipient,
+      } = await loadFixture(deployWithRealTokenizado);
+      const amount = INITIAL_BALANCE.sub(20000);
+
+      await expect(
+        swap
+          .connect(enabledRecipient)
+          .cancelSwap(0, "test")
+      ).to.be.revertedWith("SwapTwoSteps: Proposal does not exist");
+    });
+  });
+});

--- a/test/fixtures/RealDigital.js
+++ b/test/fixtures/RealDigital.js
@@ -1,0 +1,93 @@
+const { ethers } = require("hardhat");
+const { expect } = require("chai");
+const { parseReal } = require("../../util/parseFormatReal");
+const { REAL_NAME, REAL_SYMBOL } = require("../../util/constants");
+
+const MINT_AMOUNT = parseReal("100");
+const FREEZE_AMOUNT = parseReal("50");
+
+const deploy = async () => {
+  const RealDigital = await ethers.getContractFactory("RealDigital");
+  [
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  ] = await ethers.getSigners();
+  const real = await RealDigital.deploy(
+    REAL_NAME,
+    REAL_SYMBOL,
+    authority.address,
+    admin.address
+  );
+  await real.deployed();
+  return {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  };
+};
+
+const deployMintTokens = async () => {
+  const {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  } = await deploy();
+
+  await real.connect(authority).enableAccount(authority.address);
+  await real.connect(authority).enableAccount(authorizedSender.address);
+  await real.connect(authority).enableAccount(authorizedRecipient.address);
+
+  await real.connect(authority).mint(authority.address, MINT_AMOUNT);
+  expect(await real.balanceOf(authority.address)).to.equal(MINT_AMOUNT);
+
+  await real.connect(authority).mint(authorizedSender.address, MINT_AMOUNT);
+  expect(await real.balanceOf(authorizedSender.address)).to.equal(MINT_AMOUNT);
+
+  return {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  };
+};
+
+const deployMintAndFreezeTokens = async () => {
+  const {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  } = await deployMintTokens();
+  await real
+    .connect(authority)
+    .increaseFrozenBalance(authorizedSender.address, FREEZE_AMOUNT);
+  return {
+    real,
+    admin,
+    authority,
+    authorizedSender,
+    authorizedRecipient,
+    unauthorizedAccount,
+  };
+};
+
+module.exports = {
+  deploy,
+  deployMintTokens,
+  deployMintAndFreezeTokens,
+  MINT_AMOUNT,
+  FREEZE_AMOUNT
+};

--- a/test/fixtures/RealTokenizado.js
+++ b/test/fixtures/RealTokenizado.js
@@ -23,7 +23,7 @@ class RealTokenizadoParams {
 
   getAddressDiscoveryKey() {
     return ethers.utils.keccak256(
-      ethers.utils.solidityPack(["string", "uint256"], [this.name, this.cnpj8])
+      ethers.utils.solidityPack(["string", "uint256"], ["RealTokenizado", this.cnpj8])
     );
   }
 }
@@ -87,7 +87,8 @@ const deploy = async (addressDiscovery, realDigitalDefaultAccount, realTokenizad
 
 const deployAddDefaultAccount = async (
   _addressDiscovery,
-  _realDigitalDefaultAccount
+  _realDigitalDefaultAccount,
+  _realTokenizadoParams
 ) => {
   const {
     addressDiscovery,
@@ -98,7 +99,7 @@ const deployAddDefaultAccount = async (
     realTokenizadoParams,
     newReserve,
     unauthorized,
-   } = await deploy(_addressDiscovery, _realDigitalDefaultAccount);
+   } = await deploy(_addressDiscovery, _realDigitalDefaultAccount, _realTokenizadoParams);
 
   await realDigitalDefaultAccount
     .connect(authority)

--- a/test/fixtures/SwapOneStep.js
+++ b/test/fixtures/SwapOneStep.js
@@ -1,0 +1,113 @@
+const { ethers } = require("hardhat");
+const { deploy: deployRealDigital } = require("./RealDigital");
+const { deployAddDefaultAccount } = require("./RealTokenizado");
+const { RealTokenizadoParams } = require("./RealTokenizado");
+const { parseReal } = require("../../util/parseFormatReal");
+const { expect } = require("chai");
+
+const deploy = async (realDigital) => {
+  if (!realDigital) {
+    realDigital = (await deployRealDigital()).real;
+  }
+
+  const SwapOneStep = await ethers.getContractFactory("SwapOneStep");
+  const [
+    admin,
+    authority,
+    unauthorizedAccount,
+  ] = await ethers.getSigners();
+
+  const swapOneStep = await SwapOneStep.deploy(
+    realDigital.address
+  );
+  await swapOneStep.deployed();
+
+  realDigital.connect(admin).grantRole(await realDigital.MOVER_ROLE(), swapOneStep.address);
+
+  return {
+    realDigital,
+    swapOneStep
+  };
+};
+
+const INITIAL_BALANCE = parseReal("1000");
+
+
+const deployWithRealTokenizado = async (_realDigital) => {
+  const [admin, authority, rt1Reserve, rt1DefaultAccount, rt2Reserve, rt2DefaultAccount, enabledSender, enabledRecipient, unauthorized] = await ethers.getSigners();
+  const { realDigital, swapOneStep } = await deploy(_realDigital);
+  // either _realDigital was undefined and was deployed, or it was defined and was passed to deploy
+  // in either case, the correct _realDigital to be used is in realDigital returned from deploy
+  _realDigital = realDigital;
+
+  const rtp1 = new RealTokenizadoParams(
+    "RealTokenizado1",
+    "RTK1",
+    "ParticipantName1",
+    12345678,
+    rt1Reserve,
+    rt1DefaultAccount,
+  );
+  const rtp2 = new RealTokenizadoParams(
+    "RealTokenizado2",
+    "RTK2",
+    "ParticipantName2",
+    87654321,
+    rt2Reserve,
+    rt2DefaultAccount,
+  );
+
+  const { addressDiscovery, realDigitalDefaultAccount, realTokenizado: rt1 } = await deployAddDefaultAccount(undefined, undefined, rtp1);
+  const { realTokenizado: rt2 } = await deployAddDefaultAccount(addressDiscovery, realDigitalDefaultAccount, rtp2);
+
+  const enableTx1 = await rt1.connect(authority).enableAccount(enabledSender.address);
+  enableTx1.wait();
+  const enableTx2 = await rt2.connect(authority).enableAccount(enabledRecipient.address);
+  enableTx2.wait();
+
+  const enableRt1Reserve = await realDigital.connect(authority).enableAccount(rt1Reserve.address);
+  await enableRt1Reserve.wait();
+  const enableRt2Reserve = await realDigital.connect(authority).enableAccount(rt2Reserve.address);
+  await enableRt2Reserve.wait();
+
+  await realDigital.connect(authority).mint(rt1Reserve.address, INITIAL_BALANCE);
+  await rt1.connect(authority).mint(enabledSender.address, INITIAL_BALANCE);
+
+  expect(await realDigital.balanceOf(rtp1.reserve.address)).to.equal(INITIAL_BALANCE);
+  expect(await rt1.balanceOf(enabledSender.address)).to.equal(INITIAL_BALANCE);
+  expect(await realDigital.balanceOf(rtp2.reserve.address)).to.equal(0);
+  expect(await rt2.balanceOf(enabledRecipient.address)).to.equal(0);
+
+  const grantMinterRt1 = await rt1.grantRole(await rt1.MINTER_ROLE(), swapOneStep.address);
+  await grantMinterRt1.wait();
+  const grantMinterRt2 = await rt2.grantRole(await rt2.MINTER_ROLE(), swapOneStep.address);
+  await grantMinterRt2.wait();
+  const grantBurnerRt1 = await rt1.grantRole(await rt1.BURNER_ROLE(), swapOneStep.address);
+  await grantBurnerRt1.wait();
+  const grantBurnerRt2 = await rt2.grantRole(await rt2.BURNER_ROLE(), swapOneStep.address);
+  await grantBurnerRt2.wait();
+
+  return {
+    realDigital,
+    swapOneStep,
+    addressDiscovery,
+    realDigitalDefaultAccount,
+    realTokenizado1: rt1,
+    realTokenizado2: rt2,
+    realTokenizadoParams1: rtp1,
+    realTokenizadoParams2: rtp2,
+    admin,
+    authority,
+    enabledSender,
+    enabledRecipient,
+    unauthorized,
+  };
+};
+
+
+
+module.exports = {
+  deploy,
+  deployWithRealTokenizado,
+  INITIAL_BALANCE
+};

--- a/test/fixtures/SwapTwoStep.js
+++ b/test/fixtures/SwapTwoStep.js
@@ -1,0 +1,54 @@
+const { ethers } = require("hardhat");
+const { expect } = require("chai");
+const { deployTwoStepsWithRealTokenizado, INITIAL_BALANCE } = require("./Swaps");
+
+const deployInitiateSwap = async () => {
+  const {
+    realDigital,
+    swap,
+    addressDiscovery,
+    realDigitalDefaultAccount,
+    realTokenizado1,
+    realTokenizado2,
+    realTokenizadoParams1,
+    realTokenizadoParams2,
+    admin,
+    authority,
+    enabledSender,
+    enabledRecipient,
+    unauthorized,
+  } = await deployTwoStepsWithRealTokenizado();
+
+  const amount = INITIAL_BALANCE.sub(20000);
+  await swap.connect(enabledSender).startSwap(
+    realTokenizado1.address,
+    realTokenizado2.address,
+    enabledRecipient.address,
+    amount
+  );
+
+  await realTokenizado1.connect(enabledSender).increaseAllowance(swap.address, amount);
+
+  return {
+    realDigital,
+    swap,
+    addressDiscovery,
+    realDigitalDefaultAccount,
+    realTokenizado1,
+    realTokenizado2,
+    realTokenizadoParams1,
+    realTokenizadoParams2,
+    admin,
+    authority,
+    enabledSender,
+    enabledRecipient,
+    unauthorized,
+    proposalId: 0,
+  };
+};
+
+
+module.exports = {
+  deployInitiateSwap,
+  INITIAL_BALANCE,
+};

--- a/test/fixtures/Swaps.js
+++ b/test/fixtures/Swaps.js
@@ -87,6 +87,13 @@ const deployWithRealTokenizado = async (_realDigital, swapClass) => {
   const grantBurnerRt2 = await rt2.grantRole(await rt2.BURNER_ROLE(), swap.address);
   await grantBurnerRt2.wait();
 
+  if (swapClass === "SwapTwoSteps") {
+    const grantFreezerRt1 = await rt1.grantRole(await rt1.FREEZER_ROLE(), swap.address);
+    await grantFreezerRt1.wait();
+    const grantFreezerRd = await realDigital.grantRole(await realDigital.FREEZER_ROLE(), swap.address);
+    await grantFreezerRd.wait();
+  }
+
   return {
     realDigital,
     swap,
@@ -108,24 +115,24 @@ const deployOneStep = async (_realDigital) => {
   return deploy(_realDigital, "SwapOneStep");
 };
 
-const deployTwoStep = async (_realDigital) => {
-  return deploy(_realDigital, "SwapTwoStep");
+const deployTwoSteps = async (_realDigital) => {
+  return deploy(_realDigital, "SwapTwoSteps");
 };
 
 const deployOneStepWithRealTokenizado = async (_realDigital) => {
   return deployWithRealTokenizado(_realDigital, "SwapOneStep");
 };
 
-const deployTwoStepWithRealTokenizado = async (_realDigital) => {
-  return deployWithRealTokenizado(_realDigital, "SwapTwoStep");
+const deployTwoStepsWithRealTokenizado = async (_realDigital) => {
+  return deployWithRealTokenizado(_realDigital, "SwapTwoSteps");
 };
 
 
 
 module.exports = {
   deployOneStep,
-  deployTwoStep,
+  deployTwoSteps,
   deployOneStepWithRealTokenizado,
-  deployTwoStepWithRealTokenizado,
+  deployTwoStepsWithRealTokenizado,
   INITIAL_BALANCE
 };


### PR DESCRIPTION
This PR implements `SwapTwoSteps` exactly as defined in the Bacen documentation.

Assumptions and inner workings:
- when a swap is initiated the balance required to complete the swap is frozen both in the senders `RealTokenizado` and in `RealDigital`
- the balance is unfrozen just before swap execution or when the swap is cancelled
- only the recipient can execute an initiated swap
- both the sender and the recipient can cancel the swap if it's not expired
- anyone can cancel a swap that has expired

This branch is built on top of the SwapOneStep branch. Merge PR https://github.com/ioralabs/realdigital_smartcontracts/pull/14 before reviewing this one.
